### PR TITLE
Fixed incorrect group query

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -231,7 +231,7 @@ class User extends Authenticatable
     {
         $routePermissions = explode('|', $routePermissions);
         
-        $groups = $this->find(Auth::user()->id)->with('groups')->first()->groups;
+        $groups = $this->with('groups')->findOrFail(Auth::user()->id)->groups;
 
         foreach ($groups as $group) {
             foreach ($group->permissions as $permission) {


### PR DESCRIPTION
This fixes issue #8

The query used to fetch the groups had a `find` and `first` method in it. This always returned an empty result set.