### PR TITLE
Only access the integration url if one is available

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -46,7 +46,9 @@ class Category extends Model
 
     public function routeNotificationForSlack()
     {
-        return Team::find(Auth::user()->team->first()->id)->with(['integration'])->first()->integration->url;
+	$integration = Team::find(Auth::user()->team->first()->id)->with(['integration'])->first()->integration;
+
+        return $integration ? $integration->url : null;
     }
 
     public static function boot()


### PR DESCRIPTION
If a wiki was created but no integration has been created before, the `integration->url` property does not exist.