### PR TITLE
[Issue #64]. Fixed file path directory separators in DB Seeders.

### DIFF
--- a/database/seeds/Components/Integration/IntegrationActionsTableSeeder.php
+++ b/database/seeds/Components/Integration/IntegrationActionsTableSeeder.php
@@ -16,7 +16,7 @@ class IntegrationActionsTableSeeder extends Seeder
      * 
      * @var string
      */
-    private $integrationActionsFilePath = 'database\seeds\Components\Integration\integration_actions.json';
+    private $integrationActionsFilePath = 'database/seeds/Components/Integration/integration_actions.json';
 
     /**		
      * Run the database seeds.		

--- a/database/seeds/Components/Notification/NotificationCategoryTableSeeder.php
+++ b/database/seeds/Components/Notification/NotificationCategoryTableSeeder.php
@@ -15,7 +15,7 @@ class NotificationCategoryTableSeeder extends Seeder
      * 
      * @var string
      */
-    private $notificationCategoriesFilePath = 'database\seeds\Components\Notification\notification_categories.json';
+    private $notificationCategoriesFilePath = 'database/seeds/Components/Notification/notification_categories.json';
 
     /**
      * Run the database seeds.

--- a/database/seeds/Components/Page/PagesTableSeeder.php
+++ b/database/seeds/Components/Page/PagesTableSeeder.php
@@ -16,7 +16,7 @@ class PagesTableSeeder extends Seeder
      * 
      * @var string
      */
-    private $pagesFilePath = 'database\seeds\Components\Page\pages.json';
+    private $pagesFilePath = 'database/seeds/Components/Page/pages.json';
     
     /**
      * Run the database seeds.

--- a/database/seeds/Components/Permission/PermissionsTableSeeder.php
+++ b/database/seeds/Components/Permission/PermissionsTableSeeder.php
@@ -15,7 +15,7 @@ class PermissionsTableSeeder extends Seeder
      * 
      * @var string
      */
-    private $permissionsFilePath = 'database\seeds\Components\Permission\permissions.json';
+    private $permissionsFilePath = 'database/seeds/Components/Permission/permissions.json';
 
     /**
      * Run the database seeds.

--- a/database/seeds/Components/Permission/RolePermissionsTableSeeder.php
+++ b/database/seeds/Components/Permission/RolePermissionsTableSeeder.php
@@ -16,7 +16,7 @@ class RolePermissionsTableSeeder extends Seeder
      * 
      * @var string
      */
-    private $rolePermissionsFilePath = 'database\seeds\Components\Permission\role_permissions.json';
+    private $rolePermissionsFilePath = 'database/seeds/Components/Permission/role_permissions.json';
 
     /**
      * Run the database seeds.

--- a/database/seeds/Components/Role/RolesTableSeeder.php
+++ b/database/seeds/Components/Role/RolesTableSeeder.php
@@ -16,7 +16,7 @@ class RolesTableSeeder extends Seeder
      * 
      * @var string
      */
-    private $rolesFilePath = 'database\seeds\Components\Role\roles.json';
+    private $rolesFilePath = 'database/seeds/Components/Role/roles.json';
 
     /**
      * Run the database seeds.

--- a/database/seeds/Components/Space/SpacesTableSeeder.php
+++ b/database/seeds/Components/Space/SpacesTableSeeder.php
@@ -16,7 +16,7 @@ class SpacesTableSeeder extends Seeder
      * 
      * @var string
      */
-    private $spacesFilePath = 'database\seeds\Components\Space\spaces.json';
+    private $spacesFilePath = 'database/seeds/Components/Space/spaces.json';
 
     /**
      * Run the database seeds.

--- a/database/seeds/Components/Team/InvitesTableSeeder.php
+++ b/database/seeds/Components/Team/InvitesTableSeeder.php
@@ -16,7 +16,7 @@ class InvitesTableSeeder extends Seeder
      * 
      * @var string
      */
-    private $invitationsFilePath = 'database\seeds\Components\Team\invitations.json';
+    private $invitationsFilePath = 'database/seeds/Components/Team/invitations.json';
 
     /**
      * Run the database seeds.

--- a/database/seeds/Components/Team/TeamsTableSeeder.php
+++ b/database/seeds/Components/Team/TeamsTableSeeder.php
@@ -16,7 +16,7 @@ class TeamsTableSeeder extends Seeder
      * 
      * @var string
      */
-    private $teamsFilePath = 'database\seeds\Components\Team\teams.json';
+    private $teamsFilePath = 'database/seeds/Components/Team/teams.json';
 
     /**
      * Run the database seeds.

--- a/database/seeds/Components/User/UsersRolesTableSeeder.php
+++ b/database/seeds/Components/User/UsersRolesTableSeeder.php
@@ -16,7 +16,7 @@ class UsersRolesTableSeeder extends Seeder
      * 
      * @var string
      */
-    private $usersRolesFilePath = 'database\seeds\Components\User\users_roles.json';
+    private $usersRolesFilePath = 'database/seeds/Components/User/users_roles.json';
 
     /**
      * Run the database seeds.

--- a/database/seeds/Components/User/UsersTableSeeder.php
+++ b/database/seeds/Components/User/UsersTableSeeder.php
@@ -16,7 +16,7 @@ class UsersTableSeeder extends Seeder
      * 
      * @var string
      */
-    private $usersFilePath = 'database\seeds\Components\User\users.json';
+    private $usersFilePath = 'database/seeds/Components/User/users.json';
 
     /**
      * Run the database seeds.

--- a/database/seeds/Components/User/UsersTeamsTableSeeder.php
+++ b/database/seeds/Components/User/UsersTeamsTableSeeder.php
@@ -16,7 +16,7 @@ class UsersTeamsTableSeeder extends Seeder
      * 
      * @var string
      */
-    private $userTeamsFilePath = 'database\seeds\Components\User\user_teams.json';
+    private $userTeamsFilePath = 'database/seeds/Components/User/user_teams.json';
 
     /**
      * Run the database seeds.

--- a/database/seeds/Components/Wiki/WikisTableSeeder.php
+++ b/database/seeds/Components/Wiki/WikisTableSeeder.php
@@ -16,7 +16,7 @@ class WikisTableSeeder extends Seeder
      * 
      * @var string
      */
-    private $wikisFilePath = 'database\seeds\Components\Wiki\wikis.json';
+    private $wikisFilePath = 'database/seeds/Components/Wiki/wikis.json';
 
     /**
      * Run the database seeds.


### PR DESCRIPTION
Fixed issue #64 
Used `/` when referencing the JSON files paths. 