### PR TITLE
Remove hardcoded wkhtmlpdf binary

### DIFF
--- a/config/snappy.php
+++ b/config/snappy.php
@@ -5,7 +5,7 @@ return array(
 
     'pdf' => array(
         'enabled' => true,
-        'binary'  => env('SNAPPY_BINARY', 'C:/wkhtmltopdf/bin/wkhtmltopdf.exe'),
+        'binary'  => env('WKHTMLTOPDF_PATH', 'C:/wkhtmltopdf/bin/wkhtmltopdf.exe'),
         'timeout' => false,
         'options' => [],
         'env'     => [],

--- a/config/snappy.php
+++ b/config/snappy.php
@@ -5,7 +5,7 @@ return array(
 
     'pdf' => array(
         'enabled' => true,
-        'binary'  =>  'C:/wkhtmltopdf/bin/wkhtmltopdf.exe',
+        'binary'  => env('SNAPPY_BINARY', 'C:/wkhtmltopdf/bin/wkhtmltopdf.exe'),
         'timeout' => false,
         'options' => [],
         'env'     => [],


### PR DESCRIPTION
This allows for the snappy/wkhtmlpdf binary to be configured through an environment variable rather than it being hardcoded. 

Fixes issue #72 